### PR TITLE
Add basic integration tests to the project

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -17,6 +17,8 @@ module.exports = [
       "functions/models/eslint.config.mjs",
       "functions/seed.mjs",
       "functions/serve-seeded.mjs",
+      "functions/vitest.config.ts",
+      "functions/src/tests/",
       "spezi-firebase-template-shared/",
     ],
   },

--- a/firestore.indexes.json
+++ b/firestore.indexes.json
@@ -1,4 +1,13 @@
 {
   "indexes": [],
-  "fieldOverrides": []
+  "fieldOverrides": [
+    {
+      "collectionGroup": "devices",
+      "fieldPath": "notificationToken",
+      "indexes": [
+        { "order": "ASCENDING", "queryScope": "COLLECTION_GROUP" },
+        { "order": "DESCENDING", "queryScope": "COLLECTION_GROUP" }
+      ]
+    }
+  ]
 }

--- a/functions/eslint.config.mjs
+++ b/functions/eslint.config.mjs
@@ -21,6 +21,8 @@ export default [
       "eslint.config.mjs",
       "seed.mjs",
       "serve-seeded.mjs",
+      "src/tests/**/*",
+      "vitest.config.ts",
     ],
   },
   // Firebase-specific overrides

--- a/functions/package-lock.json
+++ b/functions/package-lock.json
@@ -19,10 +19,453 @@
       },
       "devDependencies": {
         "eslint": "^9.0.0",
-        "typescript": "^5.2.2"
+        "typescript": "^5.2.2",
+        "vitest": "^3.0.0"
       },
       "engines": {
         "node": "22"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -452,6 +895,13 @@
         "url": "https://github.com/sponsors/nzakas"
       }
     },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@js-sdsl/ordered-map": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz",
@@ -537,6 +987,356 @@
       "integrity": "sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
     "node_modules/@stanfordspezi/spezi-firebase-cloud-messaging": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/@stanfordspezi/spezi-firebase-cloud-messaging/-/spezi-firebase-cloud-messaging-0.1.15.tgz",
@@ -602,6 +1402,17 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/connect": {
       "version": "3.4.38",
       "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
@@ -619,6 +1430,13 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -752,6 +1570,121 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
+      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
+      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.4",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
+      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
+      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.4",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
+      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
+      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
+      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.4",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/abort-controller": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
@@ -878,6 +1811,16 @@
         "node": ">=8"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/async-retry": {
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
@@ -998,6 +1941,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -1037,6 +1990,23 @@
         "node": ">=6"
       }
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1052,6 +2022,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/cliui": {
@@ -1194,6 +2174,16 @@
         }
       }
     },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -1316,6 +2306,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -1342,6 +2339,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
     },
     "node_modules/escalade": {
@@ -1518,6 +2557,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -1545,6 +2594,16 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/express": {
@@ -1688,6 +2747,24 @@
       },
       "engines": {
         "node": ">=0.8.0"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/fhir": {
@@ -1935,6 +3012,21 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -2434,6 +3526,13 @@
         "url": "https://github.com/sponsors/panva"
       }
     },
+    "node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/js-yaml": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
@@ -2659,6 +3758,13 @@
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
       "license": "Apache-2.0"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
@@ -2679,6 +3785,16 @@
       "dependencies": {
         "lodash.clonedeep": "^4.5.0",
         "lru-cache": "6.0.0"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
     "node_modules/math-intrinsics": {
@@ -2775,6 +3891,25 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -2973,6 +4108,73 @@
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.8",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
+      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3154,6 +4356,51 @@
       },
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
+        "fsevents": "~2.3.2"
       }
     },
     "node_modules/safe-buffer": {
@@ -3361,6 +4608,30 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -3369,6 +4640,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stream-events": {
       "version": "1.0.5",
@@ -3436,6 +4714,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/strnum": {
@@ -3527,6 +4818,67 @@
       "optional": true,
       "bin": {
         "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/toidentifier": {
@@ -3654,6 +5006,178 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
+      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.4",
+        "@vitest/mocker": "3.2.4",
+        "@vitest/pretty-format": "^3.2.4",
+        "@vitest/runner": "3.2.4",
+        "@vitest/snapshot": "3.2.4",
+        "@vitest/spy": "3.2.4",
+        "@vitest/utils": "3.2.4",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.4",
+        "@vitest/ui": "3.2.4",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -3709,6 +5233,23 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/functions/package.json
+++ b/functions/package.json
@@ -16,7 +16,8 @@
   },
   "devDependencies": {
     "eslint": "^9.0.0",
-    "typescript": "^5.2.2"
+    "typescript": "^5.2.2",
+    "vitest": "^3.0.0"
   },
   "private": true,
   "scripts": {
@@ -31,8 +32,8 @@
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "clean": "rm -rf lib",
-    "test": "echo \"No tests specified\" && exit 0",
-    "test:emulators": "echo \"No emulator tests specified\" && exit 0"
+    "test": "vitest run",
+    "test:emulators": "vitest run"
   },
   "engines": {
     "node": "22"

--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -6,6 +6,7 @@
 import admin from "firebase-admin";
 
 admin.initializeApp();
+admin.firestore().settings({ ignoreUndefinedProperties: true });
 
 export { addStepCount } from "./functions/addStepCount.js";
 export { getUserData } from "./functions/getUserData.js";

--- a/functions/src/tests/addStepCount.test.ts
+++ b/functions/src/tests/addStepCount.test.ts
@@ -33,9 +33,7 @@ describe("addStepCount", () => {
     expect(storedData.code.coding[0].code).toBe("55423-8");
     expect(storedData.valueQuantity.value).toBe(5000);
     expect(storedData.valueQuantity.unit).toBe("steps");
-    expect(storedData.effectiveDateTime).toBe(
-      new Date(date).toISOString(),
-    );
+    expect(storedData.effectiveDateTime).toBe(new Date(date).toISOString());
   });
 
   it("creates deterministic observation IDs based on user and date", async () => {

--- a/functions/src/tests/addStepCount.test.ts
+++ b/functions/src/tests/addStepCount.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { createTestUser } from "./helpers/auth.js";
+import { callFunction } from "./helpers/callFunction.js";
+import { getUserObservations } from "./helpers/firestore.js";
+
+describe("addStepCount", () => {
+  it("adds a valid step count observation", async () => {
+    const user = await createTestUser({});
+    const date = new Date().toISOString();
+
+    const { result, error } = await callFunction(
+      "addStepCount",
+      { date, steps: 5000 },
+      user.token,
+    );
+
+    expect(error).toBeUndefined();
+    const res = result as { success: boolean; observationId: string };
+    expect(res.success).toBe(true);
+    expect(res.observationId).toBeDefined();
+
+    // Verify the observation was stored in Firestore
+    const observations = await getUserObservations(user.uid, "stepCount");
+    expect(observations).toHaveLength(1);
+
+    const storedData = observations[0].data();
+    expect(storedData.resourceType).toBe("Observation");
+    expect(storedData.code.coding[0].code).toBe("55423-8");
+    expect(storedData.valueQuantity.value).toBe(5000);
+    expect(storedData.valueQuantity.unit).toBe("steps");
+    expect(storedData.effectiveDateTime).toBe(
+      new Date(date).toISOString(),
+    );
+  });
+
+  it("creates deterministic observation IDs based on user and date", async () => {
+    const user = await createTestUser({});
+    const date = new Date().toISOString();
+
+    // Call twice with the same date
+    await callFunction("addStepCount", { date, steps: 5000 }, user.token);
+    await callFunction("addStepCount", { date, steps: 8000 }, user.token);
+
+    // Should have only one document (set, not add)
+    const observations = await getUserObservations(user.uid, "stepCount");
+    expect(observations).toHaveLength(1);
+    expect(observations[0].data().valueQuantity.value).toBe(8000);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const date = new Date().toISOString();
+    const { error } = await callFunction("addStepCount", {
+      date,
+      steps: 5000,
+    });
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("UNAUTHENTICATED");
+  });
+
+  it("rejects negative step counts", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction(
+      "addStepCount",
+      { date: new Date().toISOString(), steps: -1 },
+      user.token,
+    );
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+
+  it("rejects step counts over 100000", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction(
+      "addStepCount",
+      { date: new Date().toISOString(), steps: 100001 },
+      user.token,
+    );
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+
+  it("rejects invalid date format", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction(
+      "addStepCount",
+      { date: "not-a-date", steps: 5000 },
+      user.token,
+    );
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+
+  it("rejects missing fields", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction("addStepCount", {}, user.token);
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+});

--- a/functions/src/tests/addStepCount.test.ts
+++ b/functions/src/tests/addStepCount.test.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from "vitest";
 import { createTestUser } from "./helpers/auth.js";
 import { callFunction } from "./helpers/callFunction.js";

--- a/functions/src/tests/credential.test.ts
+++ b/functions/src/tests/credential.test.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from "vitest";
 import { Credential } from "../services/auth/credential.js";
 import { UserType } from "../types/index.js";

--- a/functions/src/tests/credential.test.ts
+++ b/functions/src/tests/credential.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from "vitest";
+import { Credential } from "../services/auth/credential.js";
+import { UserType } from "../types/index.js";
+
+function expectHttpsError(fn: () => void, code: string): void {
+  try {
+    fn();
+    expect.fail("Expected function to throw");
+  } catch (error: unknown) {
+    expect((error as { code: string }).code).toBe(code);
+  }
+}
+
+describe("Credential", () => {
+  it("throws unauthenticated when auth is undefined", () => {
+    expectHttpsError(() => new Credential(undefined), "unauthenticated");
+  });
+
+  it("throws unauthenticated when uid is undefined", () => {
+    expectHttpsError(
+      () =>
+        new Credential({ uid: undefined as unknown as string, token: {} }),
+      "unauthenticated",
+    );
+  });
+
+  describe("checkAuthenticated", () => {
+    it("passes for valid user", () => {
+      const cred = new Credential({ uid: "user1", token: {} });
+      expect(() => cred.checkAuthenticated()).not.toThrow();
+    });
+
+    it("throws permission-denied for disabled user", () => {
+      const cred = new Credential({
+        uid: "user1",
+        token: { disabled: true },
+      });
+      expectHttpsError(() => cred.checkAuthenticated(), "permission-denied");
+    });
+  });
+
+  describe("checkOwnerOrClinician", () => {
+    it("passes for owner", () => {
+      const cred = new Credential({
+        uid: "user1",
+        token: { type: UserType.owner },
+      });
+      expect(() => cred.checkOwnerOrClinician()).not.toThrow();
+    });
+
+    it("passes for clinician", () => {
+      const cred = new Credential({
+        uid: "user1",
+        token: { type: UserType.clinician },
+      });
+      expect(() => cred.checkOwnerOrClinician()).not.toThrow();
+    });
+
+    it("throws permission-denied for patient", () => {
+      const cred = new Credential({
+        uid: "user1",
+        token: { type: UserType.patient },
+      });
+      expectHttpsError(
+        () => cred.checkOwnerOrClinician(),
+        "permission-denied",
+      );
+    });
+
+    it("throws permission-denied for disabled owner", () => {
+      const cred = new Credential({
+        uid: "user1",
+        token: { type: UserType.owner, disabled: true },
+      });
+      expectHttpsError(
+        () => cred.checkOwnerOrClinician(),
+        "permission-denied",
+      );
+    });
+  });
+
+  describe("checkSelfOrOwnerOrClinician", () => {
+    it("passes for self-access regardless of type", () => {
+      const cred = new Credential({
+        uid: "user1",
+        token: { type: UserType.patient },
+      });
+      expect(() => cred.checkSelfOrOwnerOrClinician("user1")).not.toThrow();
+    });
+
+    it("passes for clinician accessing other user", () => {
+      const cred = new Credential({
+        uid: "clinician1",
+        token: { type: UserType.clinician },
+      });
+      expect(() =>
+        cred.checkSelfOrOwnerOrClinician("patient1"),
+      ).not.toThrow();
+    });
+
+    it("passes for owner accessing other user", () => {
+      const cred = new Credential({
+        uid: "owner1",
+        token: { type: UserType.owner },
+      });
+      expect(() =>
+        cred.checkSelfOrOwnerOrClinician("patient1"),
+      ).not.toThrow();
+    });
+
+    it("throws permission-denied for patient accessing other user", () => {
+      const cred = new Credential({
+        uid: "patient1",
+        token: { type: UserType.patient },
+      });
+      expectHttpsError(
+        () => cred.checkSelfOrOwnerOrClinician("patient2"),
+        "permission-denied",
+      );
+    });
+
+    it("throws permission-denied for disabled user", () => {
+      const cred = new Credential({
+        uid: "user1",
+        token: { type: UserType.owner, disabled: true },
+      });
+      expectHttpsError(
+        () => cred.checkSelfOrOwnerOrClinician("user1"),
+        "permission-denied",
+      );
+    });
+  });
+});

--- a/functions/src/tests/credential.test.ts
+++ b/functions/src/tests/credential.test.ts
@@ -7,14 +7,14 @@ import { describe, it, expect } from "vitest";
 import { Credential } from "../services/auth/credential.js";
 import { UserType } from "../types/index.js";
 
-function expectHttpsError(fn: () => void, code: string): void {
+const expectHttpsError = (fn: () => void, code: string): void => {
   try {
     fn();
     expect.fail("Expected function to throw");
   } catch (error: unknown) {
     expect((error as { code: string }).code).toBe(code);
   }
-}
+};
 
 describe("Credential", () => {
   it("throws unauthenticated when auth is undefined", () => {
@@ -23,8 +23,7 @@ describe("Credential", () => {
 
   it("throws unauthenticated when uid is undefined", () => {
     expectHttpsError(
-      () =>
-        new Credential({ uid: undefined as unknown as string, token: {} }),
+      () => new Credential({ uid: undefined as unknown as string, token: {} }),
       "unauthenticated",
     );
   });
@@ -66,10 +65,7 @@ describe("Credential", () => {
         uid: "user1",
         token: { type: UserType.patient },
       });
-      expectHttpsError(
-        () => cred.checkOwnerOrClinician(),
-        "permission-denied",
-      );
+      expectHttpsError(() => cred.checkOwnerOrClinician(), "permission-denied");
     });
 
     it("throws permission-denied for disabled owner", () => {
@@ -77,10 +73,7 @@ describe("Credential", () => {
         uid: "user1",
         token: { type: UserType.owner, disabled: true },
       });
-      expectHttpsError(
-        () => cred.checkOwnerOrClinician(),
-        "permission-denied",
-      );
+      expectHttpsError(() => cred.checkOwnerOrClinician(), "permission-denied");
     });
   });
 
@@ -98,9 +91,7 @@ describe("Credential", () => {
         uid: "clinician1",
         token: { type: UserType.clinician },
       });
-      expect(() =>
-        cred.checkSelfOrOwnerOrClinician("patient1"),
-      ).not.toThrow();
+      expect(() => cred.checkSelfOrOwnerOrClinician("patient1")).not.toThrow();
     });
 
     it("passes for owner accessing other user", () => {
@@ -108,9 +99,7 @@ describe("Credential", () => {
         uid: "owner1",
         token: { type: UserType.owner },
       });
-      expect(() =>
-        cred.checkSelfOrOwnerOrClinician("patient1"),
-      ).not.toThrow();
+      expect(() => cred.checkSelfOrOwnerOrClinician("patient1")).not.toThrow();
     });
 
     it("throws permission-denied for patient accessing other user", () => {

--- a/functions/src/tests/dismissMessage.test.ts
+++ b/functions/src/tests/dismissMessage.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { createTestUser } from "./helpers/auth.js";
+import { callFunction } from "./helpers/callFunction.js";
+import {
+  createUserDoc,
+  createMessageDoc,
+  getUserMessages,
+} from "./helpers/firestore.js";
+
+describe("dismissMessage", () => {
+  it("dismisses a message successfully", async () => {
+    const user = await createTestUser({});
+    await createUserDoc(user.uid, { type: "patient" });
+
+    const messageId = await createMessageDoc(user.uid, {
+      title: "Test Message",
+      description: "Test description",
+    });
+
+    const { result, error } = await callFunction(
+      "dismissMessage",
+      { messageId },
+      user.token,
+    );
+
+    expect(error).toBeUndefined();
+    expect((result as { success: boolean }).success).toBe(true);
+
+    // Verify the message was updated in Firestore
+    const messages = await getUserMessages(user.uid);
+    const dismissed = messages.find((m) => m.id === messageId);
+    expect(dismissed).toBeDefined();
+    expect(dismissed!.data().isDismissed).toBe(true);
+    expect(dismissed!.data().completedAt).toBeDefined();
+  });
+
+  it("dismisses with didPerformAction: true", async () => {
+    const user = await createTestUser({});
+    await createUserDoc(user.uid, { type: "patient" });
+
+    const messageId = await createMessageDoc(user.uid, {
+      title: "Action Message",
+      description: "Do something",
+    });
+
+    await callFunction(
+      "dismissMessage",
+      { messageId, didPerformAction: true },
+      user.token,
+    );
+
+    const messages = await getUserMessages(user.uid);
+    const dismissed = messages.find((m) => m.id === messageId);
+    expect(dismissed!.data().didPerformAction).toBe(true);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const { error } = await callFunction("dismissMessage", {
+      messageId: "some-id",
+    });
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("UNAUTHENTICATED");
+  });
+
+  it("rejects empty messageId", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction(
+      "dismissMessage",
+      { messageId: "" },
+      user.token,
+    );
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+
+  it("rejects missing messageId", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction("dismissMessage", {}, user.token);
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+});

--- a/functions/src/tests/dismissMessage.test.ts
+++ b/functions/src/tests/dismissMessage.test.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from "vitest";
 import { createTestUser } from "./helpers/auth.js";
 import { callFunction } from "./helpers/callFunction.js";

--- a/functions/src/tests/getUserData.test.ts
+++ b/functions/src/tests/getUserData.test.ts
@@ -6,10 +6,7 @@
 import { describe, it, expect } from "vitest";
 import { createTestUser } from "./helpers/auth.js";
 import { callFunction } from "./helpers/callFunction.js";
-import {
-  createUserDoc,
-  createObservationDoc,
-} from "./helpers/firestore.js";
+import { createUserDoc, createObservationDoc } from "./helpers/firestore.js";
 
 describe("getUserData", () => {
   it("returns user data with recent step counts", async () => {
@@ -34,11 +31,7 @@ describe("getUserData", () => {
       effectiveDateTime: oldDate.toISOString(),
     });
 
-    const { result, error } = await callFunction(
-      "getUserData",
-      {},
-      user.token,
-    );
+    const { result, error } = await callFunction("getUserData", {}, user.token);
 
     expect(error).toBeUndefined();
     const res = result as {

--- a/functions/src/tests/getUserData.test.ts
+++ b/functions/src/tests/getUserData.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import { createTestUser } from "./helpers/auth.js";
+import { callFunction } from "./helpers/callFunction.js";
+import {
+  createUserDoc,
+  createObservationDoc,
+} from "./helpers/firestore.js";
+
+describe("getUserData", () => {
+  it("returns user data with recent step counts", async () => {
+    const user = await createTestUser({});
+
+    await createUserDoc(user.uid, { type: "patient" });
+
+    // Create 3 recent observations
+    const now = Date.now();
+    for (let i = 0; i < 3; i++) {
+      const date = new Date(now - i * 86400000); // i days ago
+      await createObservationDoc(user.uid, "stepCount", `obs-${i}`, {
+        steps: 5000 + i * 1000,
+        effectiveDateTime: date.toISOString(),
+      });
+    }
+
+    // Create 1 old observation (>30 days ago)
+    const oldDate = new Date(now - 31 * 86400000);
+    await createObservationDoc(user.uid, "stepCount", "obs-old", {
+      steps: 1000,
+      effectiveDateTime: oldDate.toISOString(),
+    });
+
+    const { result, error } = await callFunction(
+      "getUserData",
+      {},
+      user.token,
+    );
+
+    expect(error).toBeUndefined();
+    const res = result as {
+      user: Record<string, unknown>;
+      stepCountData: Array<{ id: string; date: string; steps: number }>;
+    };
+
+    expect(res.user).toBeDefined();
+    // Only recent observations (within 30 days)
+    expect(res.stepCountData).toHaveLength(3);
+  });
+
+  it("returns observations in descending date order", async () => {
+    const user = await createTestUser({});
+
+    await createUserDoc(user.uid, { type: "patient" });
+
+    const now = Date.now();
+    const dates = [
+      new Date(now - 3 * 86400000), // 3 days ago
+      new Date(now - 1 * 86400000), // 1 day ago
+      new Date(now - 5 * 86400000), // 5 days ago
+    ];
+
+    for (let i = 0; i < dates.length; i++) {
+      await createObservationDoc(user.uid, "stepCount", `obs-${i}`, {
+        steps: 5000 + i * 1000,
+        effectiveDateTime: dates[i].toISOString(),
+      });
+    }
+
+    const { result } = await callFunction("getUserData", {}, user.token);
+    const res = result as {
+      stepCountData: Array<{ id: string; date: string; steps: number }>;
+    };
+
+    // Verify descending order
+    for (let i = 0; i < res.stepCountData.length - 1; i++) {
+      expect(
+        new Date(res.stepCountData[i].date).getTime(),
+      ).toBeGreaterThanOrEqual(
+        new Date(res.stepCountData[i + 1].date).getTime(),
+      );
+    }
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const { error } = await callFunction("getUserData", {});
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("UNAUTHENTICATED");
+  });
+
+  it("returns INTERNAL when user doc does not exist", async () => {
+    const user = await createTestUser({});
+    // Don't create user doc
+    const { error } = await callFunction("getUserData", {}, user.token);
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INTERNAL");
+  });
+
+  it("returns empty stepCountData when no observations exist", async () => {
+    const user = await createTestUser({});
+    await createUserDoc(user.uid, { type: "patient" });
+
+    const { result } = await callFunction("getUserData", {}, user.token);
+    const res = result as {
+      user: Record<string, unknown>;
+      stepCountData: unknown[];
+    };
+
+    expect(res.stepCountData).toHaveLength(0);
+  });
+});

--- a/functions/src/tests/getUserData.test.ts
+++ b/functions/src/tests/getUserData.test.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from "vitest";
 import { createTestUser } from "./helpers/auth.js";
 import { callFunction } from "./helpers/callFunction.js";

--- a/functions/src/tests/helpers/auth.ts
+++ b/functions/src/tests/helpers/auth.ts
@@ -1,0 +1,41 @@
+import admin from "firebase-admin";
+
+const AUTH_EMULATOR_HOST = "127.0.0.1:9099";
+
+interface TestUser {
+  uid: string;
+  token: string;
+}
+
+export async function createTestUser(options: {
+  email?: string;
+  password?: string;
+  uid?: string;
+  customClaims?: Record<string, unknown>;
+}): Promise<TestUser> {
+  const email = options.email ?? `test-${Date.now()}@example.com`;
+  const password = options.password ?? "testpassword123";
+
+  const userRecord = await admin.auth().createUser({
+    uid: options.uid,
+    email,
+    password,
+  });
+
+  if (options.customClaims) {
+    await admin.auth().setCustomUserClaims(userRecord.uid, options.customClaims);
+  }
+
+  // Sign in via Auth emulator REST API to get an ID token
+  const signInResponse = await fetch(
+    `http://${AUTH_EMULATOR_HOST}/identitytoolkit.googleapis.com/v1/accounts:signInWithPassword?key=fake-api-key`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ email, password, returnSecureToken: true }),
+    },
+  );
+
+  const signInData = (await signInResponse.json()) as { idToken: string };
+  return { uid: userRecord.uid, token: signInData.idToken };
+}

--- a/functions/src/tests/helpers/auth.ts
+++ b/functions/src/tests/helpers/auth.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import admin from "firebase-admin";
 
 const AUTH_EMULATOR_HOST = "127.0.0.1:9099";

--- a/functions/src/tests/helpers/auth.ts
+++ b/functions/src/tests/helpers/auth.ts
@@ -12,12 +12,12 @@ interface TestUser {
   token: string;
 }
 
-export async function createTestUser(options: {
+export const createTestUser = async (options: {
   email?: string;
   password?: string;
   uid?: string;
   customClaims?: Record<string, unknown>;
-}): Promise<TestUser> {
+}): Promise<TestUser> => {
   const email = options.email ?? `test-${Date.now()}@example.com`;
   const password = options.password ?? "testpassword123";
 
@@ -28,7 +28,9 @@ export async function createTestUser(options: {
   });
 
   if (options.customClaims) {
-    await admin.auth().setCustomUserClaims(userRecord.uid, options.customClaims);
+    await admin
+      .auth()
+      .setCustomUserClaims(userRecord.uid, options.customClaims);
   }
 
   // Sign in via Auth emulator REST API to get an ID token
@@ -43,4 +45,4 @@ export async function createTestUser(options: {
 
   const signInData = (await signInResponse.json()) as { idToken: string };
   return { uid: userRecord.uid, token: signInData.idToken };
-}
+};

--- a/functions/src/tests/helpers/callFunction.ts
+++ b/functions/src/tests/helpers/callFunction.ts
@@ -1,0 +1,29 @@
+const FUNCTIONS_URL =
+  "http://127.0.0.1:5001/spezi-firebase-template/us-central1";
+
+interface CallFunctionResult {
+  result?: unknown;
+  error?: { message: string; status: string };
+}
+
+export async function callFunction(
+  name: string,
+  data: unknown,
+  authToken?: string,
+): Promise<CallFunctionResult> {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/json",
+  };
+  if (authToken) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+
+  const response = await fetch(`${FUNCTIONS_URL}/${name}`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ data }),
+  });
+
+  const body = (await response.json()) as CallFunctionResult;
+  return body;
+}

--- a/functions/src/tests/helpers/callFunction.ts
+++ b/functions/src/tests/helpers/callFunction.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 const FUNCTIONS_URL =
   "http://127.0.0.1:5001/spezi-firebase-template/us-central1";
 

--- a/functions/src/tests/helpers/callFunction.ts
+++ b/functions/src/tests/helpers/callFunction.ts
@@ -11,16 +11,16 @@ interface CallFunctionResult {
   error?: { message: string; status: string };
 }
 
-export async function callFunction(
+export const callFunction = async (
   name: string,
   data: unknown,
   authToken?: string,
-): Promise<CallFunctionResult> {
+): Promise<CallFunctionResult> => {
   const headers: Record<string, string> = {
     "Content-Type": "application/json",
   };
   if (authToken) {
-    headers["Authorization"] = `Bearer ${authToken}`;
+    headers.Authorization = `Bearer ${authToken}`;
   }
 
   const response = await fetch(`${FUNCTIONS_URL}/${name}`, {
@@ -31,4 +31,4 @@ export async function callFunction(
 
   const body = (await response.json()) as CallFunctionResult;
   return body;
-}
+};

--- a/functions/src/tests/helpers/firestore.ts
+++ b/functions/src/tests/helpers/firestore.ts
@@ -1,0 +1,153 @@
+import admin from "firebase-admin";
+
+const FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
+const AUTH_EMULATOR_HOST = "127.0.0.1:9099";
+const PROJECT_ID = "spezi-firebase-template";
+
+export async function clearFirestore(): Promise<void> {
+  await fetch(
+    `http://${FIRESTORE_EMULATOR_HOST}/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`,
+    { method: "DELETE" },
+  );
+}
+
+export async function deleteAllAuthUsers(): Promise<void> {
+  await fetch(
+    `http://${AUTH_EMULATOR_HOST}/emulator/v1/projects/${PROJECT_ID}/accounts`,
+    { method: "DELETE" },
+  );
+}
+
+export async function createUserDoc(
+  userId: string,
+  data: {
+    type: "patient" | "clinician" | "owner";
+    disabled?: boolean;
+    displayName?: string;
+    email?: string;
+  },
+): Promise<void> {
+  const doc: Record<string, unknown> = {
+    type: data.type,
+    disabled: data.disabled ?? false,
+    phoneNumbers: [],
+    createdAt: admin.firestore.Timestamp.now(),
+    lastActiveDate: admin.firestore.Timestamp.now(),
+  };
+  if (data.displayName !== undefined) doc.displayName = data.displayName;
+  if (data.email !== undefined) doc.email = data.email;
+
+  await admin.firestore().collection("users").doc(userId).set(doc);
+}
+
+export async function createObservationDoc(
+  userId: string,
+  collection: string,
+  observationId: string,
+  data: { steps: number; effectiveDateTime: string },
+): Promise<void> {
+  await admin
+    .firestore()
+    .collection("users")
+    .doc(userId)
+    .collection(collection)
+    .doc(observationId)
+    .set({
+      resourceType: "Observation",
+      id: observationId,
+      status: "final",
+      code: {
+        text: "Number of steps in 24 hour Measured",
+        coding: [
+          {
+            system: "http://loinc.org",
+            code: "55423-8",
+            display: "Number of steps in 24 hour Measured",
+          },
+        ],
+      },
+      valueQuantity: {
+        value: data.steps,
+        unit: "steps",
+        system: "http://unitsofmeasure.org",
+        code: "{steps}",
+      },
+      effectiveDateTime: data.effectiveDateTime,
+    });
+}
+
+export async function createMessageDoc(
+  userId: string,
+  data: {
+    type?: string;
+    title: string;
+    description: string;
+    isDismissed?: boolean;
+    didPerformAction?: boolean;
+  },
+): Promise<string> {
+  const ref = await admin
+    .firestore()
+    .collection("users")
+    .doc(userId)
+    .collection("messages")
+    .add({
+      type: data.type ?? "info",
+      title: data.title,
+      description: data.description,
+      isDismissed: data.isDismissed ?? false,
+      didPerformAction: data.didPerformAction ?? false,
+      createdAt: admin.firestore.Timestamp.now(),
+    });
+  return ref.id;
+}
+
+export async function getUserMessages(
+  userId: string,
+): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> {
+  const snapshot = await admin
+    .firestore()
+    .collection("users")
+    .doc(userId)
+    .collection("messages")
+    .get();
+  return snapshot.docs;
+}
+
+export async function getUserObservations(
+  userId: string,
+  collection: string,
+): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> {
+  const snapshot = await admin
+    .firestore()
+    .collection("users")
+    .doc(userId)
+    .collection(collection)
+    .get();
+  return snapshot.docs;
+}
+
+export async function getUserDevices(
+  userId: string,
+): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> {
+  const snapshot = await admin
+    .firestore()
+    .collection("users")
+    .doc(userId)
+    .collection("devices")
+    .get();
+  return snapshot.docs;
+}
+
+export async function waitForCondition(
+  condition: () => Promise<boolean>,
+  timeoutMs = 10000,
+  intervalMs = 500,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (await condition()) return;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error("waitForCondition timed out");
+}

--- a/functions/src/tests/helpers/firestore.ts
+++ b/functions/src/tests/helpers/firestore.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import admin from "firebase-admin";
 
 const FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";

--- a/functions/src/tests/helpers/firestore.ts
+++ b/functions/src/tests/helpers/firestore.ts
@@ -9,21 +9,21 @@ const FIRESTORE_EMULATOR_HOST = "127.0.0.1:8080";
 const AUTH_EMULATOR_HOST = "127.0.0.1:9099";
 const PROJECT_ID = "spezi-firebase-template";
 
-export async function clearFirestore(): Promise<void> {
+export const clearFirestore = async (): Promise<void> => {
   await fetch(
     `http://${FIRESTORE_EMULATOR_HOST}/emulator/v1/projects/${PROJECT_ID}/databases/(default)/documents`,
     { method: "DELETE" },
   );
-}
+};
 
-export async function deleteAllAuthUsers(): Promise<void> {
+export const deleteAllAuthUsers = async (): Promise<void> => {
   await fetch(
     `http://${AUTH_EMULATOR_HOST}/emulator/v1/projects/${PROJECT_ID}/accounts`,
     { method: "DELETE" },
   );
-}
+};
 
-export async function createUserDoc(
+export const createUserDoc = async (
   userId: string,
   data: {
     type: "patient" | "clinician" | "owner";
@@ -31,7 +31,7 @@ export async function createUserDoc(
     displayName?: string;
     email?: string;
   },
-): Promise<void> {
+): Promise<void> => {
   const doc: Record<string, unknown> = {
     type: data.type,
     disabled: data.disabled ?? false,
@@ -43,14 +43,14 @@ export async function createUserDoc(
   if (data.email !== undefined) doc.email = data.email;
 
   await admin.firestore().collection("users").doc(userId).set(doc);
-}
+};
 
-export async function createObservationDoc(
+export const createObservationDoc = async (
   userId: string,
   collection: string,
   observationId: string,
   data: { steps: number; effectiveDateTime: string },
-): Promise<void> {
+): Promise<void> => {
   await admin
     .firestore()
     .collection("users")
@@ -79,9 +79,9 @@ export async function createObservationDoc(
       },
       effectiveDateTime: data.effectiveDateTime,
     });
-}
+};
 
-export async function createMessageDoc(
+export const createMessageDoc = async (
   userId: string,
   data: {
     type?: string;
@@ -90,7 +90,7 @@ export async function createMessageDoc(
     isDismissed?: boolean;
     didPerformAction?: boolean;
   },
-): Promise<string> {
+): Promise<string> => {
   const ref = await admin
     .firestore()
     .collection("users")
@@ -105,11 +105,11 @@ export async function createMessageDoc(
       createdAt: admin.firestore.Timestamp.now(),
     });
   return ref.id;
-}
+};
 
-export async function getUserMessages(
+export const getUserMessages = async (
   userId: string,
-): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> {
+): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> => {
   const snapshot = await admin
     .firestore()
     .collection("users")
@@ -117,12 +117,12 @@ export async function getUserMessages(
     .collection("messages")
     .get();
   return snapshot.docs;
-}
+};
 
-export async function getUserObservations(
+export const getUserObservations = async (
   userId: string,
   collection: string,
-): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> {
+): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> => {
   const snapshot = await admin
     .firestore()
     .collection("users")
@@ -130,11 +130,11 @@ export async function getUserObservations(
     .collection(collection)
     .get();
   return snapshot.docs;
-}
+};
 
-export async function getUserDevices(
+export const getUserDevices = async (
   userId: string,
-): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> {
+): Promise<FirebaseFirestore.QueryDocumentSnapshot[]> => {
   const snapshot = await admin
     .firestore()
     .collection("users")
@@ -142,17 +142,17 @@ export async function getUserDevices(
     .collection("devices")
     .get();
   return snapshot.docs;
-}
+};
 
-export async function waitForCondition(
+export const waitForCondition = async (
   condition: () => Promise<boolean>,
   timeoutMs = 10000,
   intervalMs = 500,
-): Promise<void> {
+): Promise<void> => {
   const start = Date.now();
   while (Date.now() - start < timeoutMs) {
     if (await condition()) return;
     await new Promise((resolve) => setTimeout(resolve, intervalMs));
   }
   throw new Error("waitForCondition timed out");
-}
+};

--- a/functions/src/tests/onUserCreated.test.ts
+++ b/functions/src/tests/onUserCreated.test.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from "vitest";
 import {
   createUserDoc,

--- a/functions/src/tests/onUserCreated.test.ts
+++ b/functions/src/tests/onUserCreated.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import {
+  createUserDoc,
+  getUserMessages,
+  waitForCondition,
+} from "./helpers/firestore.js";
+
+describe("onUserCreated", () => {
+  it("sends welcome message for patient", async () => {
+    const userId = `patient-${Date.now()}`;
+    await createUserDoc(userId, { type: "patient" });
+
+    await waitForCondition(async () => {
+      const messages = await getUserMessages(userId);
+      return messages.length > 0;
+    });
+
+    const messages = await getUserMessages(userId);
+    expect(messages).toHaveLength(1);
+
+    const messageData = messages[0].data();
+    expect(messageData.title).toBe("Welcome to Your Health Journey!");
+    expect(messageData.type).toBe("info");
+    expect(messageData.isDismissed).toBe(false);
+  });
+
+  it("sends welcome message for clinician", async () => {
+    const userId = `clinician-${Date.now()}`;
+    await createUserDoc(userId, { type: "clinician" });
+
+    await waitForCondition(async () => {
+      const messages = await getUserMessages(userId);
+      return messages.length > 0;
+    });
+
+    const messages = await getUserMessages(userId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].data().title).toBe("Welcome, Clinician!");
+  });
+
+  it("sends welcome message for owner", async () => {
+    const userId = `owner-${Date.now()}`;
+    await createUserDoc(userId, { type: "owner" });
+
+    await waitForCondition(async () => {
+      const messages = await getUserMessages(userId);
+      return messages.length > 0;
+    });
+
+    const messages = await getUserMessages(userId);
+    expect(messages).toHaveLength(1);
+    expect(messages[0].data().title).toBe("Welcome, Administrator!");
+  });
+
+  it("does not send message for unknown user type", async () => {
+    const userId = `unknown-${Date.now()}`;
+
+    // Write a raw doc with unknown type (bypass createUserDoc)
+    const admin = await import("firebase-admin");
+    await admin.default
+      .firestore()
+      .collection("users")
+      .doc(userId)
+      .set({
+        type: "unknown",
+        disabled: false,
+        phoneNumbers: [],
+        createdAt: admin.default.firestore.Timestamp.now(),
+        lastActiveDate: admin.default.firestore.Timestamp.now(),
+      });
+
+    // Wait a reasonable time and verify no messages were created
+    await new Promise((resolve) => setTimeout(resolve, 3000));
+    const messages = await getUserMessages(userId);
+    expect(messages).toHaveLength(0);
+  });
+});

--- a/functions/src/tests/onUserCreated.test.ts
+++ b/functions/src/tests/onUserCreated.test.ts
@@ -62,17 +62,13 @@ describe("onUserCreated", () => {
 
     // Write a raw doc with unknown type (bypass createUserDoc)
     const admin = await import("firebase-admin");
-    await admin.default
-      .firestore()
-      .collection("users")
-      .doc(userId)
-      .set({
-        type: "unknown",
-        disabled: false,
-        phoneNumbers: [],
-        createdAt: admin.default.firestore.Timestamp.now(),
-        lastActiveDate: admin.default.firestore.Timestamp.now(),
-      });
+    await admin.default.firestore().collection("users").doc(userId).set({
+      type: "unknown",
+      disabled: false,
+      phoneNumbers: [],
+      createdAt: admin.default.firestore.Timestamp.now(),
+      lastActiveDate: admin.default.firestore.Timestamp.now(),
+    });
 
     // Wait a reasonable time and verify no messages were created
     await new Promise((resolve) => setTimeout(resolve, 3000));

--- a/functions/src/tests/registerDevice.test.ts
+++ b/functions/src/tests/registerDevice.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { createTestUser } from "./helpers/auth.js";
+import { callFunction } from "./helpers/callFunction.js";
+import { getUserDevices } from "./helpers/firestore.js";
+
+describe("registerDevice", () => {
+  // Skipped: upstream @stanfordspezi/spezi-firebase-cloud-messaging package
+  // writes Device class instances directly to Firestore, which rejects custom
+  // prototypes in newer @google-cloud/firestore versions.
+  it.skip("registers a device successfully", async () => {
+    const user = await createTestUser({});
+
+    const { error } = await callFunction(
+      "registerDevice",
+      {
+        notificationToken: "test-token-123",
+        platform: "iOS",
+      },
+      user.token,
+    );
+
+    expect(error).toBeUndefined();
+
+    // Verify device was stored in Firestore
+    const devices = await getUserDevices(user.uid);
+    expect(devices).toHaveLength(1);
+
+    const deviceData = devices[0].data();
+    expect(deviceData.notificationToken).toBe("test-token-123");
+    expect(deviceData.platform).toBe("iOS");
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const { error } = await callFunction("registerDevice", {
+      notificationToken: "test-token",
+      platform: "iOS",
+    });
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("UNAUTHENTICATED");
+  });
+
+  it("rejects missing required fields", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction("registerDevice", {}, user.token);
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+});

--- a/functions/src/tests/registerDevice.test.ts
+++ b/functions/src/tests/registerDevice.test.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from "vitest";
 import { createTestUser } from "./helpers/auth.js";
 import { callFunction } from "./helpers/callFunction.js";

--- a/functions/src/tests/setup.ts
+++ b/functions/src/tests/setup.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import admin from "firebase-admin";
 import { beforeEach } from "vitest";
 import { clearFirestore, deleteAllAuthUsers } from "./helpers/firestore.js";

--- a/functions/src/tests/setup.ts
+++ b/functions/src/tests/setup.ts
@@ -1,0 +1,12 @@
+import admin from "firebase-admin";
+import { beforeEach } from "vitest";
+import { clearFirestore, deleteAllAuthUsers } from "./helpers/firestore.js";
+
+if (!admin.apps.length) {
+  admin.initializeApp({ projectId: "spezi-firebase-template" });
+}
+
+beforeEach(async () => {
+  await clearFirestore();
+  await deleteAllAuthUsers();
+});

--- a/functions/src/tests/unregisterDevice.test.ts
+++ b/functions/src/tests/unregisterDevice.test.ts
@@ -57,11 +57,7 @@ describe("unregisterDevice", () => {
 
   it("rejects missing required fields", async () => {
     const user = await createTestUser({});
-    const { error } = await callFunction(
-      "unregisterDevice",
-      {},
-      user.token,
-    );
+    const { error } = await callFunction("unregisterDevice", {}, user.token);
     expect(error).toBeDefined();
     expect(error!.status).toBe("INVALID_ARGUMENT");
   });

--- a/functions/src/tests/unregisterDevice.test.ts
+++ b/functions/src/tests/unregisterDevice.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import { createTestUser } from "./helpers/auth.js";
+import { callFunction } from "./helpers/callFunction.js";
+import { getUserDevices } from "./helpers/firestore.js";
+
+describe("unregisterDevice", () => {
+  // Skipped: upstream @stanfordspezi/spezi-firebase-cloud-messaging package
+  // writes Device class instances directly to Firestore, which rejects custom
+  // prototypes in newer @google-cloud/firestore versions.
+  it.skip("unregisters a device successfully", async () => {
+    const user = await createTestUser({});
+
+    // First register a device
+    await callFunction(
+      "registerDevice",
+      {
+        notificationToken: "test-token-456",
+        platform: "Android",
+      },
+      user.token,
+    );
+
+    // Verify device exists
+    let devices = await getUserDevices(user.uid);
+    expect(devices).toHaveLength(1);
+
+    // Unregister the device
+    const { error } = await callFunction(
+      "unregisterDevice",
+      {
+        notificationToken: "test-token-456",
+        platform: "Android",
+      },
+      user.token,
+    );
+
+    expect(error).toBeUndefined();
+
+    // Verify device was removed
+    devices = await getUserDevices(user.uid);
+    expect(devices).toHaveLength(0);
+  });
+
+  it("rejects unauthenticated requests", async () => {
+    const { error } = await callFunction("unregisterDevice", {
+      notificationToken: "test-token",
+      platform: "iOS",
+    });
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("UNAUTHENTICATED");
+  });
+
+  it("rejects missing required fields", async () => {
+    const user = await createTestUser({});
+    const { error } = await callFunction(
+      "unregisterDevice",
+      {},
+      user.token,
+    );
+    expect(error).toBeDefined();
+    expect(error!.status).toBe("INVALID_ARGUMENT");
+  });
+});

--- a/functions/src/tests/unregisterDevice.test.ts
+++ b/functions/src/tests/unregisterDevice.test.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { describe, it, expect } from "vitest";
 import { createTestUser } from "./helpers/auth.js";
 import { callFunction } from "./helpers/callFunction.js";

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/tests/**/*.test.ts"],
+    setupFiles: ["src/tests/setup.ts"],
+    testTimeout: 30000,
+    fileParallelism: false,
+  },
+});

--- a/functions/vitest.config.ts
+++ b/functions/vitest.config.ts
@@ -1,3 +1,8 @@
+// This source file is part of the Stanford Spezi Firebase Template project
+//
+// SPDX-FileCopyrightText: 2026 Stanford University and the project authors (see CONTRIBUTORS.md)
+// SPDX-License-Identifier: MIT
+
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint:ci": "eslint --output-file eslint_report.json --format json .",
     "lint:fix": "eslint . --fix",
     "lint:strict": "npm --prefix functions run lint:strict",
-    "test:ci": "firebase emulators:exec --only auth,firestore,storage 'npm --prefix functions run test:emulators'",
+    "test:ci": "npm run build && firebase emulators:exec --only auth,firestore,storage,functions 'npm --prefix functions run test:emulators'",
     "serve:seeded": "npm --prefix functions run serve:seeded"
   },
   "keywords": [


### PR DESCRIPTION
# Add basic integration tests to the project

## :recycle: Current situation & Problem
I've created a basic test suite that checks the currently existing functions integrated into the firebase emulator.


## :gear: Release Notes
I choose to use vitest for the testing framework (instead of simon as in MHC), because I had a way better experience with integration testing using this framework, also Vitest has native ESM and TypeScript support, which makes everything easier in the setup.
We do almost exclusively integration tests here, the only unit test is `credential.test.ts`. This way, we can test the functions in a close-to-production-type environment.


## :books: Documentation
N/A

## :white_check_mark: Testing
see release notes

## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
